### PR TITLE
fix(tests): add httpx — fastapi.testclient requires it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.52.1
 sqlalchemy==2.0.51
 pydantic==2.13.4
 pytest==7.4.4
+httpx==0.28.1


### PR DESCRIPTION
`tests/conftest.py` imports `fastapi.testclient.TestClient`, which is built on `httpx`, but `requirements.txt` never declared it. Every test run died at conftest import with `ModuleNotFoundError: No module named 'httpx'` before collecting a single test — this is what TheSwarm's Ralph Loop kept hitting on cycles 8170b32ca48f and d4b6fcd3ce61.