### PR TITLE
[#186] Add GET /dashboard route to render dashboard.html

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy==2.0.52
 pydantic==2.13.5
 pytest==7.4.4
 httpx==0.28.1
+jinja2==3.1.6

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,11 @@
 """FastAPI application main module."""
 
-from fastapi import FastAPI
+from pathlib import Path
+
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 
 from .database import engine
 from .models import Base
@@ -28,6 +32,8 @@ app.add_middleware(
 # Include routers
 app.include_router(tours.router)
 
+templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+
 
 @app.get("/")
 def read_root():
@@ -39,3 +45,9 @@ def read_root():
 def health_check():
     """Health check endpoint."""
     return {"status": "healthy"}
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+def read_dashboard(request: Request):
+    """Render the dashboard shell; all data is loaded client-side via HTMX."""
+    return templates.TemplateResponse(request, "dashboard.html")

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Concert Tour Dashboard</title>
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+</head>
+<body>
+    <header>
+        <h1>Concert Tour Dashboard</h1>
+    </header>
+
+    <main>
+        <section id="stats-cards" aria-label="Tour statistics"
+                 hx-get="/api/v1/dashboard/stats"
+                 hx-trigger="load"
+                 hx-swap="innerHTML">
+            <!-- Stats cards are loaded client-side via HTMX -->
+        </section>
+
+        <section id="tour-overview" aria-label="Tour overview"
+                 hx-get="/api/v1/dashboard/tours"
+                 hx-trigger="load"
+                 hx-swap="innerHTML">
+            <!-- Tour overview is loaded client-side via HTMX -->
+        </section>
+    </main>
+</body>
+</html>

--- a/tests/test_dashboard_route.py
+++ b/tests/test_dashboard_route.py
@@ -1,0 +1,30 @@
+"""Tests for the GET /dashboard route.
+
+The route only renders the dashboard shell template — no business data is
+embedded server-side. Dynamic content is loaded client-side via HTMX calls
+to the dashboard API endpoints (added in a follow-up task), so these tests
+only assert the shell renders successfully with its stats/overview
+containers present.
+"""
+
+
+def test_dashboard_returns_200(client):
+    response = client.get("/dashboard")
+    assert response.status_code == 200
+
+
+def test_dashboard_content_type_is_html(client):
+    response = client.get("/dashboard")
+    assert response.headers["content-type"].startswith("text/html")
+
+
+def test_dashboard_contains_key_markers(client):
+    response = client.get("/dashboard")
+    assert 'id="tour-overview"' in response.text
+    assert 'id="stats-cards"' in response.text
+
+
+def test_dashboard_does_not_embed_business_data(client):
+    """The shell must not hardcode tour/concert data — that's loaded via HTMX."""
+    response = client.get("/dashboard")
+    assert "hx-get" in response.text


### PR DESCRIPTION
## Summary

Implements #186: Add GET /dashboard route to render dashboard.html

## Changes

```
requirements.txt              |  1 +
 src/main.py                   | 14 +++++++++++++-
 src/templates/dashboard.html  | 29 +++++++++++++++++++++++++++++
 tests/test_dashboard_route.py | 30 ++++++++++++++++++++++++++++++
 4 files changed, 73 insertions(+), 1 deletion(-)
```

## Tests

All tests pass

Closes #186

---
*Generated by swarm-dev-agent*