### PR TITLE
[#185] Create dashboard.html base template with layout and dark theme styling

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from .database import engine
@@ -32,7 +33,9 @@ app.add_middleware(
 # Include routers
 app.include_router(tours.router)
 
-templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+BASE_DIR = Path(__file__).resolve().parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 
 
 @app.get("/")

--- a/src/static/css/dashboard.css
+++ b/src/static/css/dashboard.css
@@ -1,0 +1,240 @@
+:root {
+  /* Backgrounds */
+  --color-bg: #121212;
+  --color-surface: #1c1c1e;
+  --color-surface-elevated: #262629;
+  --color-border: #333336;
+
+  /* Text */
+  --color-text-primary: #f5f5f7;
+  --color-text-secondary: #a1a1a6;
+  --color-text-muted: #6e6e73;
+
+  /* Accent palette */
+  --color-accent: #7c5cff;
+  --color-accent-hover: #9781ff;
+  --color-accent-secondary: #22d3ee;
+  --color-success: #34d399;
+  --color-danger: #f87171;
+
+  /* Typography */
+  --font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.375rem;
+  --font-size-xl: 1.75rem;
+
+  /* Spacing & radius */
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--color-bg);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-base);
+  line-height: 1.5;
+}
+
+h1, h2, h3 {
+  font-weight: 600;
+  margin: 0;
+}
+
+a {
+  color: var(--color-accent-secondary);
+}
+
+.dashboard {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: var(--spacing-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+}
+
+.dashboard-header h1 {
+  font-size: var(--font-size-xl);
+}
+
+.dashboard-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+}
+
+.card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+}
+
+/* Quick actions */
+.quick-actions {
+  display: flex;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-block;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background-color: var(--color-accent);
+  color: var(--color-text-primary);
+}
+
+.btn-primary:hover {
+  background-color: var(--color-accent-hover);
+}
+
+.btn-secondary {
+  background-color: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
+}
+
+.btn.is-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+/* Tour overview */
+.tour-overview .tour-name {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  margin-bottom: var(--spacing-xs);
+}
+
+.tour-overview .tour-dates {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-md);
+}
+
+.progress-bar {
+  width: 100%;
+  height: 10px;
+  background-color: var(--color-surface-elevated);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background-color: var(--color-accent);
+  transition: width 0.3s ease;
+}
+
+/* Statistics cards */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: var(--spacing-md);
+}
+
+.stat-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  text-align: center;
+}
+
+.stat-label {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat-value {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+}
+
+/* Calendar grid shell */
+.calendar-grid {
+  min-height: 400px;
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-surface);
+}
+
+/* Tablet breakpoint */
+@media (max-width: 1024px) {
+  .stats-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard {
+    padding: var(--spacing-md);
+    gap: var(--spacing-lg);
+  }
+
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .quick-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .quick-actions .btn {
+    width: 100%;
+    text-align: center;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .calendar-grid {
+    min-height: 250px;
+  }
+}
+
+@media (max-width: 480px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -2,28 +2,89 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Concert Tour Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='css/dashboard.css') }}">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
 </head>
 <body>
-    <header>
-        <h1>Concert Tour Dashboard</h1>
-    </header>
+    <div class="dashboard">
+        <header class="dashboard-header">
+            <h1>Concert Tour Dashboard</h1>
 
-    <main>
-        <section id="stats-cards" aria-label="Tour statistics"
-                 hx-get="/api/v1/dashboard/stats"
-                 hx-trigger="load"
-                 hx-swap="innerHTML">
-            <!-- Stats cards are loaded client-side via HTMX -->
-        </section>
+            <!--
+                No concert-create or setlist page/route exists on `main` yet:
+                only the JSON `/api/v1/tours/` API and unused Concert schemas
+                are implemented, there is no Concert router, setlist model,
+                or any HTML page for either. Rather than invent URLs, these
+                actions are rendered disabled until those routes land.
+            -->
+            <div class="quick-actions" aria-label="Quick actions">
+                <a id="quick-action-add-concert"
+                   class="btn btn-primary is-disabled"
+                   href="#"
+                   role="button"
+                   aria-disabled="true"
+                   tabindex="-1"
+                   title="Not yet available: no concert-create route exists on main">
+                    Add Concert
+                </a>
+                <a id="quick-action-view-setlist"
+                   class="btn btn-secondary is-disabled"
+                   href="#"
+                   role="button"
+                   aria-disabled="true"
+                   tabindex="-1"
+                   title="Not yet available: no setlist route exists on main">
+                    View Setlist
+                </a>
+            </div>
+        </header>
 
-        <section id="tour-overview" aria-label="Tour overview"
-                 hx-get="/api/v1/dashboard/tours"
-                 hx-trigger="load"
-                 hx-swap="innerHTML">
-            <!-- Tour overview is loaded client-side via HTMX -->
-        </section>
-    </main>
+        <main class="dashboard-main">
+            <section id="tour-overview" class="card tour-overview" aria-label="Tour overview"
+                     hx-get="/api/v1/dashboard/tours"
+                     hx-trigger="load"
+                     hx-swap="innerHTML">
+                <div id="tour-name" class="tour-name">Loading tour&hellip;</div>
+                <div id="tour-dates" class="tour-dates"></div>
+                <div id="tour-progress" class="tour-progress">
+                    <div class="progress-bar">
+                        <div class="progress-bar-fill" style="width: 0%"></div>
+                    </div>
+                </div>
+            </section>
+
+            <section id="stats-cards" class="stats-grid" aria-label="Tour statistics"
+                     hx-get="/api/v1/dashboard/stats"
+                     hx-trigger="load"
+                     hx-swap="innerHTML">
+                <div id="stat-concerts" class="stat-card">
+                    <span class="stat-label">Concerts</span>
+                    <span class="stat-value">&mdash;</span>
+                </div>
+                <div id="stat-cities" class="stat-card">
+                    <span class="stat-label">Cities</span>
+                    <span class="stat-value">&mdash;</span>
+                </div>
+                <div id="stat-countries" class="stat-card">
+                    <span class="stat-label">Countries</span>
+                    <span class="stat-value">&mdash;</span>
+                </div>
+                <div id="stat-capacity" class="stat-card">
+                    <span class="stat-label">Total Capacity</span>
+                    <span class="stat-value">&mdash;</span>
+                </div>
+                <div id="stat-revenue" class="stat-card">
+                    <span class="stat-label">Projected Revenue</span>
+                    <span class="stat-value">&mdash;</span>
+                </div>
+            </section>
+
+            <section id="calendar-grid" class="calendar-grid" aria-label="Concert calendar">
+                <!-- Empty shell: populated by a later task -->
+            </section>
+        </main>
+    </div>
 </body>
 </html>

--- a/tests/test_dashboard_route.py
+++ b/tests/test_dashboard_route.py
@@ -28,3 +28,35 @@ def test_dashboard_does_not_embed_business_data(client):
     """The shell must not hardcode tour/concert data — that's loaded via HTMX."""
     response = client.get("/dashboard")
     assert "hx-get" in response.text
+
+
+def test_dashboard_contains_calendar_grid_shell(client):
+    response = client.get("/dashboard")
+    assert 'id="calendar-grid"' in response.text
+
+
+def test_dashboard_contains_stat_card_placeholders(client):
+    response = client.get("/dashboard")
+    for stat_id in ("stat-concerts", "stat-cities", "stat-countries", "stat-capacity", "stat-revenue"):
+        assert f'id="{stat_id}"' in response.text
+
+
+def test_dashboard_quick_actions_do_not_link_to_invented_routes(client):
+    """No concert-create or setlist route exists on `main` yet, so the quick
+    action buttons must not point at invented URLs — they're rendered
+    disabled until those routes exist."""
+    response = client.get("/dashboard")
+    assert 'id="quick-action-add-concert"' in response.text
+    assert 'id="quick-action-view-setlist"' in response.text
+    assert 'aria-disabled="true"' in response.text
+
+
+def test_dashboard_links_dark_theme_stylesheet(client):
+    response = client.get("/dashboard")
+    assert "dashboard.css" in response.text
+
+
+def test_dashboard_stylesheet_is_served(client):
+    response = client.get("/static/css/dashboard.css")
+    assert response.status_code == 200
+    assert "--color-bg" in response.text


### PR DESCRIPTION
## Summary

Implements #185: Create dashboard.html base template with layout and dark theme styling

## Changes

```
src/main.py                   |   5 +-
 src/static/css/dashboard.css  | 240 ++++++++++++++++++++++++++++++++++++++++++
 src/templates/dashboard.html  |  95 ++++++++++++++---
 tests/test_dashboard_route.py |  32 ++++++
 4 files changed, 354 insertions(+), 18 deletions(-)
```

## Tests

All tests pass

Closes #185

---
*Generated by swarm-dev-agent*