### PR TITLE
[#181] Create dashboard test fixtures with realistic multi-concert tour data

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,5 +2,7 @@
 
 from ..database import Base
 from .tour import Tour
+from .venue import Venue
+from .concert import Concert
 
-__all__ = ["Base", "Tour"]
+__all__ = ["Base", "Tour", "Venue", "Concert"]

--- a/src/models/concert.py
+++ b/src/models/concert.py
@@ -1,0 +1,21 @@
+"""SQLAlchemy model for Concert entity."""
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric
+from sqlalchemy.orm import relationship
+
+from ..database import Base
+
+
+class Concert(Base):
+    """Concert database model, linking a Tour to a Venue on a given date."""
+
+    __tablename__ = "concerts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tour_id = Column(Integer, ForeignKey("tours.id"), nullable=False, index=True)
+    venue_id = Column(Integer, ForeignKey("venues.id"), nullable=False, index=True)
+    date_time = Column(DateTime, nullable=False)
+    ticket_price = Column(Numeric(10, 2), nullable=True)
+
+    tour = relationship("Tour", backref="concerts")
+    venue = relationship("Venue", backref="concerts")

--- a/src/models/venue.py
+++ b/src/models/venue.py
@@ -1,0 +1,17 @@
+"""SQLAlchemy model for Venue entity."""
+
+from sqlalchemy import Column, Integer, String
+
+from ..database import Base
+
+
+class Venue(Base):
+    """Venue database model."""
+
+    __tablename__ = "venues"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(200), nullable=False)
+    city = Column(String(100), nullable=False)
+    country = Column(String(100), nullable=False)
+    capacity = Column(Integer, nullable=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,12 @@ from sqlalchemy.pool import StaticPool
 from src.main import app
 from src.database import get_db, Base
 from tests.fixtures.dashboard_data import build_multi_concert_tour_fixtures, attach_tour_ids
+from tests.fixtures.dashboard_fixtures import (
+    build_empty_tour,
+    build_full_tour_with_concerts,
+    build_future_only_tour,
+    build_past_only_tour,
+)
 
 # In-memory + StaticPool: a plain on-disk file here would be opened by both this
 # module's engine and tests/test_tours.py's own separate engine/autouse fixture,
@@ -54,6 +60,22 @@ def client():
 
 
 @pytest.fixture
+def db_session():
+    """Raw ORM session for tests/fixtures that need direct database access.
+
+    Bound to the same in-memory StaticPool engine as `client`, so records
+    committed here are visible through the app's `get_db` override too.
+    Tables are recreated per test by the autouse `setup_database` fixture
+    above, so no state leaks between tests.
+    """
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
 def multi_concert_tour_fixtures():
     """Raw realistic tour + concert payloads, not yet persisted."""
     return build_multi_concert_tour_fixtures()
@@ -68,3 +90,28 @@ def seeded_multi_concert_tours(client, multi_concert_tour_fixtures):
         assert response.status_code == 201
         tour_ids.append(response.json()["id"])
     return attach_tour_ids(multi_concert_tour_fixtures, tour_ids)
+
+
+@pytest.fixture
+def tour_with_many_concerts(db_session):
+    """A tour with 10+ concerts spanning past, present, and future dates,
+    tied to multiple distinct venues through real foreign keys."""
+    return build_full_tour_with_concerts(db_session)
+
+
+@pytest.fixture
+def empty_tour(db_session):
+    """A tour with zero concerts (empty state)."""
+    return build_empty_tour(db_session)
+
+
+@pytest.fixture
+def future_only_tour(db_session):
+    """A tour with only future concerts (no completed shows)."""
+    return build_future_only_tour(db_session)
+
+
+@pytest.fixture
+def past_only_tour(db_session):
+    """A tour with only past concerts (fully completed)."""
+    return build_past_only_tour(db_session)

--- a/tests/fixtures/dashboard_fixtures.py
+++ b/tests/fixtures/dashboard_fixtures.py
@@ -1,0 +1,163 @@
+"""ORM-backed dashboard test fixtures: tours, venues, and concerts.
+
+`tests/fixtures/dashboard_data.py` predates the persisted `Concert`/`Venue`
+models and seeds tours through the API with in-memory `ConcertCreate`
+payloads. This module builds on the `Venue` and `Concert` SQLAlchemy models
+and persists everything through a real ORM session, so every foreign key
+(`Concert.tour_id`, `Concert.venue_id`) is a real id from a committed row
+rather than a hardcoded literal like `venue_id=1`.
+"""
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from src.models import Concert, Tour, Venue
+
+_VENUE_TEMPLATES = [
+    {"name": "Madison Square Garden", "city": "New York", "country": "USA", "capacity": 20000},
+    {"name": "The O2 Arena", "city": "London", "country": "UK", "capacity": 18000},
+    {"name": "Accor Arena", "city": "Paris", "country": "France", "capacity": 15000},
+    {"name": "Tokyo Dome", "city": "Tokyo", "country": "Japan", "capacity": 42000},
+    {"name": "United Center", "city": "Chicago", "country": "USA", "capacity": 23500},
+    {"name": "Scotiabank Arena", "city": "Toronto", "country": "Canada", "capacity": 19800},
+    {"name": "Crypto.com Arena", "city": "Los Angeles", "country": "USA", "capacity": 20000},
+    {"name": "Red Rocks Amphitheatre", "city": "Morrison", "country": "USA", "capacity": 9525},
+    {"name": "Sydney Opera House", "city": "Sydney", "country": "Australia", "capacity": 2679},
+    {"name": "Massey Hall", "city": "Toronto", "country": "Canada", "capacity": 2765},
+    {"name": "Ryman Auditorium", "city": "Nashville", "country": "USA", "capacity": 2362},
+]
+
+
+def create_venues(db_session, count=None):
+    """Persist and return distinct `Venue` rows."""
+    templates = _VENUE_TEMPLATES[:count] if count else _VENUE_TEMPLATES
+    venues = [Venue(**template) for template in templates]
+    db_session.add_all(venues)
+    db_session.commit()
+    for venue in venues:
+        db_session.refresh(venue)
+    return venues
+
+
+def create_tour(db_session, name, artist, start_date, end_date, status, description=""):
+    """Persist and return a `Tour` row."""
+    tour = Tour(
+        name=name,
+        artist=artist,
+        start_date=start_date,
+        end_date=end_date,
+        status=status,
+        description=description,
+    )
+    db_session.add(tour)
+    db_session.commit()
+    db_session.refresh(tour)
+    return tour
+
+
+def create_concert(db_session, tour, venue, day_offset, ticket_price, base_time):
+    """Persist and return a `Concert` linked to a real tour and venue via FK."""
+    concert = Concert(
+        tour_id=tour.id,
+        venue_id=venue.id,
+        date_time=base_time + timedelta(days=day_offset),
+        ticket_price=Decimal(ticket_price),
+    )
+    db_session.add(concert)
+    db_session.commit()
+    db_session.refresh(concert)
+    return concert
+
+
+def build_full_tour_with_concerts(db_session, base_time=None):
+    """A tour with 11 concerts spanning past, present, and future dates,
+    cycled across 8 distinct venues (some cities are revisited, as real
+    tours often do).
+    """
+    base_time = base_time or datetime.now()
+    venues = create_venues(db_session, count=8)
+    tour = create_tour(
+        db_session,
+        name="Neon Skyline World Tour",
+        artist="Aurora Belle",
+        start_date=(base_time - timedelta(days=60)).date(),
+        end_date=(base_time + timedelta(days=90)).date(),
+        status="active",
+        description="A synth-pop arena tour spanning three continents.",
+    )
+    day_offsets = [-45, -30, -15, -3, -1, 0, 2, 10, 25, 40, 60]
+    concerts = [
+        create_concert(
+            db_session,
+            tour,
+            venues[i % len(venues)],
+            offset,
+            ticket_price=f"{80 + i * 5}.00",
+            base_time=base_time,
+        )
+        for i, offset in enumerate(day_offsets)
+    ]
+    return {"tour": tour, "venues": venues, "concerts": concerts}
+
+
+def build_empty_tour(db_session, base_time=None):
+    """A tour with zero concerts (empty state)."""
+    base_time = base_time or datetime.now()
+    tour = create_tour(
+        db_session,
+        name="Unannounced Tour",
+        artist="TBD Collective",
+        start_date=(base_time + timedelta(days=120)).date(),
+        end_date=(base_time + timedelta(days=150)).date(),
+        status="planned",
+        description="Dates not yet announced.",
+    )
+    return {"tour": tour, "venues": [], "concerts": []}
+
+
+def build_future_only_tour(db_session, base_time=None):
+    """A tour where every concert is scheduled in the future (no completed
+    shows yet).
+    """
+    base_time = base_time or datetime.now()
+    venues = create_venues(db_session, count=4)
+    tour = create_tour(
+        db_session,
+        name="Homecoming Revival Tour",
+        artist="The Midnight Collective",
+        start_date=(base_time + timedelta(days=10)).date(),
+        end_date=(base_time + timedelta(days=90)).date(),
+        status="planned",
+        description="A career-spanning tour celebrating a decade together.",
+    )
+    day_offsets = [15, 30, 50, 75]
+    concerts = [
+        create_concert(
+            db_session, tour, venues[i % len(venues)], offset, ticket_price="95.00", base_time=base_time
+        )
+        for i, offset in enumerate(day_offsets)
+    ]
+    return {"tour": tour, "venues": venues, "concerts": concerts}
+
+
+def build_past_only_tour(db_session, base_time=None):
+    """A tour that is fully completed — every concert is in the past."""
+    base_time = base_time or datetime.now()
+    venues = create_venues(db_session, count=4)
+    tour = create_tour(
+        db_session,
+        name="River Stone Farewell Tour",
+        artist="River Stone",
+        start_date=(base_time - timedelta(days=120)).date(),
+        end_date=(base_time - timedelta(days=30)).date(),
+        status="completed",
+        description="An intimate acoustic run through mid-size theaters.",
+    )
+    day_offsets = [-110, -90, -60, -35]
+    concerts = [
+        create_concert(
+            db_session, tour, venues[i % len(venues)], offset, ticket_price="65.00", base_time=base_time
+        )
+        for i, offset in enumerate(day_offsets)
+    ]
+    return {"tour": tour, "venues": venues, "concerts": concerts}

--- a/tests/test_dashboard_orm_fixtures.py
+++ b/tests/test_dashboard_orm_fixtures.py
@@ -1,0 +1,66 @@
+"""Tests for the ORM-backed dashboard fixtures (tours, venues, concerts).
+
+Unlike `tests/test_dashboard_fixtures.py` (which locks in the API/schema
+based seed data from `tests/fixtures/dashboard_data.py`), these tests
+exercise the persisted `Venue`/`Concert` models directly through the ORM,
+verifying real foreign key relationships and per-test isolation.
+"""
+
+from datetime import datetime
+
+from src.models import Concert, Venue
+
+
+def test_tour_with_many_concerts_has_at_least_ten_concerts(tour_with_many_concerts):
+    assert len(tour_with_many_concerts["concerts"]) >= 10
+
+
+def test_tour_with_many_concerts_spans_past_present_and_future(tour_with_many_concerts):
+    now = datetime.now()
+    dates = [c.date_time for c in tour_with_many_concerts["concerts"]]
+    assert any(d < now for d in dates)
+    assert any(d > now for d in dates)
+
+
+def test_tour_with_many_concerts_uses_multiple_distinct_venues(tour_with_many_concerts):
+    venue_ids = {c.venue_id for c in tour_with_many_concerts["concerts"]}
+    assert len(venue_ids) >= 3
+
+
+def test_concert_foreign_keys_reference_real_persisted_rows(tour_with_many_concerts):
+    tour = tour_with_many_concerts["tour"]
+    venue_ids = {v.id for v in tour_with_many_concerts["venues"]}
+    for concert in tour_with_many_concerts["concerts"]:
+        assert concert.tour_id == tour.id
+        assert concert.venue_id in venue_ids
+
+
+def test_concerts_are_queryable_through_the_session(db_session, tour_with_many_concerts):
+    tour = tour_with_many_concerts["tour"]
+    concerts = db_session.query(Concert).filter(Concert.tour_id == tour.id).all()
+    assert len(concerts) == len(tour_with_many_concerts["concerts"])
+
+
+def test_empty_tour_has_zero_concerts(empty_tour, db_session):
+    assert empty_tour["concerts"] == []
+    count = db_session.query(Concert).filter(Concert.tour_id == empty_tour["tour"].id).count()
+    assert count == 0
+
+
+def test_future_only_tour_has_no_past_concerts(future_only_tour):
+    now = datetime.now()
+    assert len(future_only_tour["concerts"]) >= 1
+    assert all(c.date_time > now for c in future_only_tour["concerts"])
+
+
+def test_past_only_tour_has_no_future_concerts(past_only_tour):
+    now = datetime.now()
+    assert len(past_only_tour["concerts"]) >= 1
+    assert all(c.date_time < now for c in past_only_tour["concerts"])
+
+
+def test_fixtures_do_not_leak_state_between_tests(db_session):
+    """The autouse `setup_database` fixture recreates tables per test, so no
+    venues/concerts from other tests' fixtures should be visible here."""
+    assert db_session.query(Venue).count() == 0
+    assert db_session.query(Concert).count() == 0


### PR DESCRIPTION
## Summary

Implements #181: Create dashboard test fixtures with realistic multi-concert tour data

## Changes

```
src/models/__init__.py               |   4 +-
 src/models/concert.py                |  21 +++++
 src/models/venue.py                  |  17 ++++
 tests/conftest.py                    |  47 ++++++++++
 tests/fixtures/dashboard_fixtures.py | 163 +++++++++++++++++++++++++++++++++++
 tests/test_dashboard_orm_fixtures.py |  66 ++++++++++++++
 6 files changed, 317 insertions(+), 1 deletion(-)
```

## Tests

All tests pass

Closes #181

---
*Generated by swarm-dev-agent*